### PR TITLE
#69 Upgrade j8585 to 1.14.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: java
 jdk:
-  - oraclejdk8
-  - oraclejdk9
+  - oraclejdk12
+  - oraclejdk13
   - openjdk10
   - openjdk11
+  - openjdk12
 
 cache:
   directories:

--- a/pom.xml
+++ b/pom.xml
@@ -20,11 +20,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Versions -->
-        <j8583.version>1.12.0</j8583.version>
+        <j8583.version>1.14.1</j8583.version>
         <mockito.version>2.23.4</mockito.version>
-        <netty.version>[4.1.31.Final,4.2)</netty.version>
-        <slf4j.version>[1.7.25,1.7.999)</slf4j.version>
-        <spring.version>5.1.3.RELEASE</spring.version>
+        <netty.version>[4.1.42.Final,4.2)</netty.version>
+        <slf4j.version>[1.7.28,1.7.999)</slf4j.version>
+        <spring.version>5.2.0.RELEASE</spring.version>
     </properties>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Versions -->
         <j8583.version>1.14.1</j8583.version>
-        <mockito.version>2.23.4</mockito.version>
+        <mockito.version>3.1.0</mockito.version>
         <netty.version>[4.1.42.Final,4.2)</netty.version>
         <slf4j.version>[1.7.28,1.7.999)</slf4j.version>
         <spring.version>5.2.0.RELEASE</spring.version>


### PR DESCRIPTION
 Upgrade dependencies:
- j8585@1.14.1
- Netty@4.1.42
- Slf4j@1.7.28
- Spring@5.2.0

Don't build under Oracle JDK 8 any more.
Now building under:
  - oraclejdk12
  - oraclejdk13
  - openjdk10
  - openjdk11
  - openjdk12 