### PR TITLE
Add support for string encoded frame length header

### DIFF
--- a/src/main/java/com/github/kpavlov/jreactive8583/ConnectorConfiguration.java
+++ b/src/main/java/com/github/kpavlov/jreactive8583/ConnectorConfiguration.java
@@ -52,6 +52,7 @@ public abstract class ConnectorConfiguration {
     private boolean replyOnError;
     private boolean addLoggingHandler;
     private boolean logSensitiveData;
+    private final boolean encodeFrameLengthAsString;
     private int[] sensitiveDataFields;
     private boolean logFieldDescription;
     private final int frameLengthFieldLength;
@@ -71,6 +72,7 @@ public abstract class ConnectorConfiguration {
         frameLengthFieldLength = builder.frameLengthFieldLength;
         frameLengthFieldAdjust = builder.frameLengthFieldAdjust;
         frameLengthFieldOffset = builder.frameLengthFieldOffset;
+        encodeFrameLengthAsString = builder.encodeFrameLengthAsString;
     }
 
     /**
@@ -176,6 +178,21 @@ public abstract class ConnectorConfiguration {
         this.logSensitiveData = logSensitiveData;
     }
 
+    /**
+     * Returns <code>true</code> if the length header is to be encoded as a String, as opposed to the default binary
+     * <p>
+     * Default value is <code>false</code> (frame length header is binary encoded).
+     * </p>
+     * <p>
+     * Used with @link frameLengthFieldLength, @link frameLengthFieldOffset and @link frameLengthFieldAdjust
+     * </p>
+     *
+     * @return <code>true</code> if frame length header is binary encoded
+     */
+    public boolean encodeFrameLengthAsString() {
+        return encodeFrameLengthAsString;
+    }
+
     public boolean logFieldDescription() {
         return logFieldDescription;
     }
@@ -264,6 +281,7 @@ public abstract class ConnectorConfiguration {
         private boolean logFieldDescription = true;
         private boolean logSensitiveData = true;
         private boolean replyOnError = false;
+        private boolean encodeFrameLengthAsString = false;
         private int idleTimeout = DEFAULT_IDLE_TIMEOUT_SECONDS;
         private int maxFrameLength = DEFAULT_MAX_FRAME_LENGTH;
         private int workerThreadsCount = 0; // use netty default
@@ -368,6 +386,19 @@ public abstract class ConnectorConfiguration {
          */
         public B logSensitiveData(boolean logSensitiveData) {
             this.logSensitiveData = logSensitiveData;
+            return (B) this;
+        }
+
+        /**
+         * Should encode frame length header as string, as opposed to default binary encoding.
+         * <p>
+         * Used with @link frameLengthFieldLength, @link frameLengthFieldOffset and @link frameLengthFieldAdjust
+         *
+         * @param encodeFrameLengthAsString <code>true</code> to encode frame length header as String
+         * @return The same {@link Builder}
+         */
+        public B encodeFrameLengthAsString(Boolean encodeFrameLengthAsString) {
+            this.encodeFrameLengthAsString = encodeFrameLengthAsString;
             return (B) this;
         }
 

--- a/src/main/java/com/github/kpavlov/jreactive8583/netty/codec/Iso8583Encoder.java
+++ b/src/main/java/com/github/kpavlov/jreactive8583/netty/codec/Iso8583Encoder.java
@@ -5,6 +5,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToByteEncoder;
+import io.netty.util.CharsetUtil;
 
 import java.nio.ByteBuffer;
 
@@ -12,9 +13,11 @@ import java.nio.ByteBuffer;
 public class Iso8583Encoder extends MessageToByteEncoder<IsoMessage> {
 
     private final int lengthHeaderLength;
+    private final boolean encodeLengthHeaderAsString;
 
-    public Iso8583Encoder(int lengthHeaderLength) {
+    public Iso8583Encoder(int lengthHeaderLength, boolean encodeLengthHeaderAsString) {
         this.lengthHeaderLength = lengthHeaderLength;
+        this.encodeLengthHeaderAsString = encodeLengthHeaderAsString;
     }
 
     @Override
@@ -22,6 +25,11 @@ public class Iso8583Encoder extends MessageToByteEncoder<IsoMessage> {
         if (lengthHeaderLength == 0) {
             byte[] bytes = isoMessage.writeData();
             out.writeBytes(bytes);
+        } else if (encodeLengthHeaderAsString) {
+            byte[] data = isoMessage.writeData();
+            String lengthHeader = String.format("%0" + lengthHeaderLength + "d", data.length);
+            out.writeBytes(lengthHeader.getBytes(CharsetUtil.US_ASCII));
+            out.writeBytes(data);
         } else {
             ByteBuffer byteBuffer = isoMessage.writeToBuffer(lengthHeaderLength);
             out.writeBytes(byteBuffer);

--- a/src/main/java/com/github/kpavlov/jreactive8583/netty/codec/StringLengthFieldBasedFrameDecoder.java
+++ b/src/main/java/com/github/kpavlov/jreactive8583/netty/codec/StringLengthFieldBasedFrameDecoder.java
@@ -1,0 +1,39 @@
+package com.github.kpavlov.jreactive8583.netty.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.util.CharsetUtil;
+
+import java.nio.ByteOrder;
+import java.nio.charset.Charset;
+
+/**
+ *  Netty's {@link LengthFieldBasedFrameDecoder} assumes the frame length header is a binary encoded integer.
+ *  This overrides it's frame length decoding to implement the case when the frame length header is String encoded.
+ *
+ *  Uses {@link CharsetUtil#US_ASCII} for decoding
+ */
+public class StringLengthFieldBasedFrameDecoder extends LengthFieldBasedFrameDecoder {
+
+    /**
+     * @see LengthFieldBasedFrameDecoder
+     */
+    public StringLengthFieldBasedFrameDecoder(
+        int maxFrameLength,
+        int lengthFieldOffset, int lengthFieldLength,
+        int lengthAdjustment, int initialBytesToStrip) {
+        super(
+            maxFrameLength,
+            lengthFieldOffset, lengthFieldLength, lengthAdjustment,
+            initialBytesToStrip);
+    }
+
+    @Override
+    protected long getUnadjustedFrameLength(ByteBuf buf, int offset, int length, ByteOrder order) {
+        buf = buf.order(order);
+        byte[] lengthBytes = new byte[length];
+        buf.getBytes(offset, lengthBytes);
+        String s = new String(lengthBytes, CharsetUtil.US_ASCII);
+        return Long.parseLong(s);
+    }
+}


### PR DESCRIPTION
Hello @kpavlov and other contributors, 

first, let me thank you for this library. I just started using it and it looks like it's going to help me save a lot of time.

Now, to the issue I had - I'm integrating with a vendor which doesn't use a binary frame length header, but a 4 byte, zero padded, ASCII encoded one. For example, an ISO message of length 93 would have the length header of `0093`.

Since the first stage in the ChannelPipeline is Netty's `LengthFieldBasedFrameDecoder` and it expects a binary length header, I needed to extend it and override it's `getUnadjustedFrameLength` method in [StringLengthFieldBasedFrameDecoder](https://github.com/oradian/jreactive-8583/blob/master/src/main/java/com/github/kpavlov/jreactive8583/netty/codec/StringLengthFieldBasedFrameDecoder.java).

Then, I did some config plumbing in `ConnectorConfiguration` which is used in `Iso8583Encoder` and `Iso8583ChannelInitializer`.

Currently, US_ASCII is hardcoded when encoding and decoding, but I'd be willing to make that configurable if it's a realistic use case, which I'm not aware of.

Usage example for the new configuration:

```scala
val serverConfiguration = ServerConfiguration.newBuilder()
        .frameLengthFieldLength(4)
        .encodeFrameLengthAsString(true)
        .build
```
Existing tests are passing, but I haven't added new tests, only tested it manually. I will add tests if this PR has a chance of being accepted. I'd be glad to discuss it and take suggestions.

Cheers,
Bojan