### PR TITLE
Fix echo request identification and support all ISO-8583 versions

### DIFF
--- a/src/main/java/com/github/kpavlov/jreactive8583/netty/pipeline/EchoMessageListener.java
+++ b/src/main/java/com/github/kpavlov/jreactive8583/netty/pipeline/EchoMessageListener.java
@@ -1,6 +1,7 @@
 package com.github.kpavlov.jreactive8583.netty.pipeline;
 
 import com.github.kpavlov.jreactive8583.IsoMessageListener;
+import com.github.kpavlov.jreactive8583.iso.MessageClass;
 import com.github.kpavlov.jreactive8583.iso.MessageFactory;
 import com.solab.iso8583.IsoMessage;
 import io.netty.channel.ChannelHandlerContext;
@@ -18,7 +19,7 @@ public class EchoMessageListener<T extends IsoMessage> implements IsoMessageList
 
     @Override
     public boolean applies(final IsoMessage isoMessage) {
-        return isoMessage != null && isoMessage.getType() == 0x800;
+        return isoMessage != null && (isoMessage.getType() & MessageClass.NETWORK_MANAGEMENT.value()) != 0;
     }
 
     /**


### PR DESCRIPTION
Hi!
I'd like to propose this small fix. It does two things.
* Removes magic constant Since you have MessageClass enum.
* Adds support for all ISO 8583 versions (type may be `0x0800`, `0x1800` etc).

PS Sorry my last PR #109 was removed by github somehow.