### PR TITLE
Add online ISO 8583 parser to ISO 8583 Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Message processing is described in the following diagram:
 - Introduction to ISO8583: http://www.codeproject.com/Articles/100084/Introduction-to-ISO-8583
 - NPM package for Packing and unpacking ISO 8583 messages: https://www.npmjs.com/package/iso-8583
 - [ISO 8583 wiki page](https://en.wikipedia.org/wiki/ISO_8583)
+- Online ISO 8583 parser (client-side, nothing uploaded): https://iso8583parser.com/
 
 [iso8583]: https://en.wikipedia.org/wiki/ISO_8583
 


### PR DESCRIPTION
This adds one line to the "ISO 8583 Links" section, alongside the beginner's guide and the CodeProject intro:

`- Online ISO 8583 parser (client-side, nothing uploaded): https://iso8583parser.com/`

Useful when someone integrating jreactive-8583 wants to eyeball a raw message dump without writing code first. A message can also be shared pre-parsed via the `?m=<message>` URL parameter, which is handy in bug reports and issue threads.

Parsing runs entirely in the browser — no upload, works offline — so it is safe to paste real message dumps into.

Disclosure: I built and maintain this tool. It is free and has no signup. Happy to close this if you would rather keep the list to written guides.